### PR TITLE
remove concat token in place of python native add

### DIFF
--- a/multi-agent_orchestration/lib/ast.ml
+++ b/multi-agent_orchestration/lib/ast.ml
@@ -35,7 +35,7 @@ and expr_node =
   | EBinOp  of binop * expr * expr
 
 
-and binop = Add | Sub | Mul | Div | Concat  
+and binop = Add | Sub | Mul | Div
 
 type statement = 
   {statement_node: statement_node;

--- a/multi-agent_orchestration/lib/codegen/codegen_expr.ml
+++ b/multi-agent_orchestration/lib/codegen/codegen_expr.ml
@@ -91,8 +91,6 @@ and binop (op : py_binop)(buffer: Buffer.t) =
 
   | PyDiv -> Buffer.add_string buffer " / ";
 
-  | PyConcat -> failwith "not implemented"
-
 and compare_operator (op : compare_operator) (buffer: Buffer.t) =
   match op with
   | Eq -> Buffer.add_string buffer " == ";

--- a/multi-agent_orchestration/lib/parser.mly
+++ b/multi-agent_orchestration/lib/parser.mly
@@ -19,7 +19,7 @@
 
 %token LET WRITE_FILE READ_FILE PRINT
 
-%token PLUS MINUS TIMES DIV CONCAT
+%token PLUS MINUS TIMES DIV
 
 %token RESOURCE ANTHROPIC OPENAI GEMINI GROK
 
@@ -79,7 +79,7 @@ typ:
 | TINT {TInt}| TCODE {TCode} | TFLOAT {TFloat} | TBOOL {TBool}| TTEXT {TText}| TFILE {TFile} | ident = IDENT { TCustomType ident }
 
 operand:
-| PLUS {Add} | MINUS {Sub} |  TIMES {Mul} | DIV {Div} | CONCAT {Concat}
+| PLUS {Add} | MINUS {Sub} |  TIMES {Mul} | DIV {Div}
 
 constant:
 | const = INT { CInt const }

--- a/multi-agent_orchestration/lib/py_ast.ml
+++ b/multi-agent_orchestration/lib/py_ast.ml
@@ -20,7 +20,7 @@ and py_constant =
   | PyString of string
   | PyNone
 
-and py_binop = PyAdd | PySub | PyMul | PyDiv | PyConcat
+and py_binop = PyAdd | PySub | PyMul | PyDiv
 
 type args = string list
 

--- a/multi-agent_orchestration/lib/translate/translate_expr.ml
+++ b/multi-agent_orchestration/lib/translate/translate_expr.ml
@@ -46,4 +46,3 @@ and binop (binop: Typed_ast.binop) : Py_ast.py_binop =
   | Typed_ast.Sub -> Py_ast.PySub
   | Typed_ast.Mul -> Py_ast.PyMul
   | Typed_ast.Div -> Py_ast.PyDiv
-  | Typed_ast.Concat -> Py_ast.PyConcat

--- a/multi-agent_orchestration/lib/typed_ast.ml
+++ b/multi-agent_orchestration/lib/typed_ast.ml
@@ -20,7 +20,7 @@ type constant =
   | CFile  of string
   | CCustomType of name
 
-type binop = Add | Sub | Mul | Div | Concat
+type binop = Add | Sub | Mul | Div
 
 
 type expr = {

--- a/multi-agent_orchestration/lib/typing.ml
+++ b/multi-agent_orchestration/lib/typing.ml
@@ -197,22 +197,19 @@ and check_binop (opperand : Ast.binop) (expr_1 : Ast.expr) (expr_2 : Ast.expr) (
     | Ast.Mul -> Mul
     | Ast.Div -> Div
     | Ast.Sub -> Sub
-    | Ast.Concat -> Concat
     in
 
   let result_typ = 
   match opperand, typed_expr_1.expr_typ, typed_expr_2.expr_typ with
-  | Concat, TText, TText -> TText
-  | Concat, TCode, TText -> TText
-  | Concat, TText, TCode -> TText
-  | Concat, TCode, TCode -> TText
+  | Add, TText, TText -> TText
+  | Add, TCode, TText -> TText
+  | Add, TText, TCode -> TText
+  | Add, TCode, TCode -> TText
   | _, TInt,   TInt   -> TInt
   | _, TFloat, TFloat -> TFloat
   | _, TFloat, TInt   -> TFloat
   | _, TInt,   TFloat -> TFloat
-  | Add, TText,   TText -> TText
-  | Concat, _, _ -> error location "Concat requires Text operands"
-  | _, typ1, typ2    -> error location ("Arithmetic requires numeric operands, got " ^
+  | _, typ1, typ2    -> error location ("Arithmetic requires compatible operands, got " ^
                      string_of_typ typ1 ^ " and " ^ string_of_typ typ2) in
     EBinOp (t_opperand, typed_expr_1, typed_expr_2), result_typ
   


### PR DESCRIPTION
- removing all current concat tokens

- rewriting typing to use 'add' instead of 'concat' on exprs that used concat before
- fixing mapping from new ast (only add, no concat) to py_ast (no py_ast concat node anymore. only add node)