### PR TITLE
Refactoring SReadFile to EReadFile 

### DIFF
--- a/multi-agent_orchestration/lib/ast.ml
+++ b/multi-agent_orchestration/lib/ast.ml
@@ -33,6 +33,7 @@ and expr_node =
   | ECall  of name * expr list * name option
   | EField  of expr * name   (** verdict.score *)
   | EBinOp  of binop * expr * expr
+  | EReadFile of expr       
 
 
 and binop = Add | Sub | Mul | Div
@@ -44,8 +45,7 @@ type statement =
 and statement_node =  
   | SLet   of name * expr      (** x = f(y) on R *)  
   | SPrint of expr
-  | SWriteFile of expr * expr  (** write_file(path, content) *)  
-  | SReadFile of expr       
+  | SWriteFile of expr * expr  (** write_file(path, content) *)      
   
 type resource_declaration = {  
   resource_name: name;

--- a/multi-agent_orchestration/lib/parser.mly
+++ b/multi-agent_orchestration/lib/parser.mly
@@ -73,6 +73,7 @@ expr_node:
     { ECall (ident, List.map (fun e -> e) args, Some r) }
 | expr_1 = expr; DOT; ident = IDENT { EField (expr_1, ident) }
 | expr_1 = expr; operand = operand; expr_2 = expr { EBinOp (operand, expr_1, expr_2)}
+| READ_FILE ; LPAREN ; arg = expr ; RPAREN { EReadFile arg }
 ;
 
 typ: 
@@ -114,15 +115,6 @@ stmt_node:
           col  = $startpos.pos_cnum - $startpos.pos_bol;
         };
     }, expr)}
-| READ_FILE ; LPAREN ; file = FILE ; RPAREN { 
-    SReadFile {
-      expr_node= EConst (CFile file);
-      expr_location = {
-          file = $startpos.pos_fname;
-          line = $startpos.pos_lnum;
-          col  = $startpos.pos_cnum - $startpos.pos_bol;
-      };
-    } } 
 
 declaration:
 | RESOURCE; ident=IDENT; ASSIGN; provider=provider; LPAREN; model=TEXT; optionals=resource_optionals; RPAREN ; NEWLINE { 

--- a/multi-agent_orchestration/lib/translate/translate_expr.ml
+++ b/multi-agent_orchestration/lib/translate/translate_expr.ml
@@ -16,7 +16,6 @@ and expr_node (node: Typed_ast.expr_node) : Py_ast.py_expr =
     let file_arg = expr path_expr in
     let open_call = Py_ast.PyCall (Py_ast.PyName "open", [file_arg; Py_ast.PyConst (Py_ast.PyString "r")], []) in
     Py_ast.PyCall (Py_ast.PyAttr (open_call, "read"), [], [])
-  | Typed_ast.ECall (name, expr_list, on_resource_option) -> raise Not_found
 
   | Typed_ast.EField (expr_record, flield_name, typ) ->
     let py_expr = expr expr_record in

--- a/multi-agent_orchestration/lib/translate/translate_expr.ml
+++ b/multi-agent_orchestration/lib/translate/translate_expr.ml
@@ -11,7 +11,10 @@ and expr_node (node: Typed_ast.expr_node) : Py_ast.py_expr =
     let binop_expr_2 = expr expr_2 in
     let binop_opperation = binop opperation in
     Py_ast.PyBinOp (binop_opperation, binop_expr_1, binop_expr_2)
-
+  | Typed_ast.EReadFile path_expr ->
+    let file_arg = expr path_expr in
+    let open_call = Py_ast.PyCall (Py_ast.PyName "open", [file_arg; Py_ast.PyConst (Py_ast.PyString "r")], []) in
+    Py_ast.PyCall (Py_ast.PyAttr (open_call, "read"), [], [])
   | Typed_ast.ECall (name, expr_list, on_resource_option) -> raise Not_found
   
   (*

--- a/multi-agent_orchestration/lib/translate/translate_statement.ml
+++ b/multi-agent_orchestration/lib/translate/translate_statement.ml
@@ -3,17 +3,11 @@ open Typed_ast
 
 let statement (stmt: statement) : py_statement = 
   match stmt with
-  | SLet (name, typ, expr) -> PyAssign (name, Translate_expr.expr expr)
+  | SLet (name, _, expr) -> PyAssign (name, Translate_expr.expr expr)
   | SPrint expr -> 
     let value = Translate_expr.expr expr in
     PyExpr (PyCall (PyName "print", [value], []))
-    (*PyExpr (PyCall (PyName "print", [ Translate_expr.expr expr], []))*)
-  | SReadFile expr -> 
-    let file = Translate_expr.expr expr in
-    let open_call = PyCall (PyName "open", [file; PyConst (PyString "r")], []) in
-    let read_call = PyAttr (open_call, "read") in
-    PyExpr read_call
-    (*PyExpr (PyCall (PyAttr (PyCall (PyName "open", [Translate_expr.expr expr; PyConst (PyString "r")], []), "read"), [], []))*)
+    
   
   | SWriteFile (expr_1, expr_2) -> 
     let file = Translate_expr.expr expr_1 in
@@ -21,4 +15,4 @@ let statement (stmt: statement) : py_statement =
     let open_call =PyCall (PyName "open", [file; PyConst (PyString "w")], []) in
     let write_call = PyCall (PyAttr(open_call, "write"), [content_expr], []) in
     PyExpr write_call
-    (*PyExpr (PyCall (PyAttr (PyCall (PyName "open", [Translate_expr.expr expr_1; PyConst (PyString "w")], []), "write"), [Translate_expr.expr expr_2], []))*)
+    

--- a/multi-agent_orchestration/lib/typed_ast.ml
+++ b/multi-agent_orchestration/lib/typed_ast.ml
@@ -34,7 +34,7 @@ and expr_node =
   | ECall  of name * expr list * name option
   | EField of expr * name * typ
   | EBinOp of binop * expr * expr
-
+  | EReadFile of expr
 
 and resource_declaration = {
   resource_name:     name;
@@ -48,7 +48,6 @@ type statement =
   | SLet       of name * typ * expr
   | SPrint     of expr
   | SWriteFile of expr * expr
-  | SReadFile  of expr
 
 
 type prompt_part =

--- a/multi-agent_orchestration/lib/typing.ml
+++ b/multi-agent_orchestration/lib/typing.ml
@@ -121,7 +121,11 @@ and check_expr_node (node : Ast.expr_node) (location: Ast.location) delta gamma 
   | Ast.ECall (func_name, args, resource_optional) -> check_func_call func_name args resource_optional delta gamma alpha beta location
   | Ast.EField (e, field_name) -> check_field e field_name location delta gamma alpha beta
   | Ast.EBinOp (opperand, e1, e2) -> check_binop opperand e1 e2 location delta gamma alpha beta
-    
+  | Ast.EReadFile path_expr ->
+    let typed_path = expr path_expr delta gamma alpha beta in
+    if not (check_subtype typed_path.expr_typ TText) then
+      type_mismatch location typed_path.expr_typ TText;
+    EReadFile typed_path, TText
 and check_constant (const: Ast.constant) delta (location: Ast.location) : expr_node * typ = 
   let const, typ = match const with
       | Ast.CText  text           -> CText text, TText
@@ -236,11 +240,7 @@ and check_statement_node (node: Ast.statement_node) (location: Ast.location) del
       type_mismatch location typed_content.expr_typ TText;
     SWriteFile (typed_path, typed_content)
 
-  | Ast.SReadFile path_expr ->
-    let typed_path = expr path_expr delta gamma alpha beta in
-    if not (check_subtype typed_path.expr_typ TFile) then
-      type_mismatch location typed_path.expr_typ TFile;
-    SReadFile typed_path
+
 
 and check_prompt_holes (func : Ast.func_declaration) delta gamma alpha beta: prompt_part list =
   let gamma_local : variable_env = Hashtbl.create (List.length func.func_params) in


### PR DESCRIPTION
Result of changes:
- read_file("doc.txt") /* Before — result silently discarded */
- content = read_file("doc.txt") /* After — result is usable */

### read_file is now an expression so its result can be assigned and composed freely 